### PR TITLE
Check if content type header contains the CloudEventsContentType

### DIFF
--- a/pkg/cloudevents/envelope.go
+++ b/pkg/cloudevents/envelope.go
@@ -65,7 +65,7 @@ func NewFromRequest(req *http.Request) (*Envelope, error) {
 	// suggests that another format (like Avro) might be used. So we're going
 	// with the most conservative reading.
 	// https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md#3-http-message-mapping
-	if ct := req.Header.Get("content-type"); ct != CloudEventsContentType {
+	if ct := req.Header.Get("content-type"); !strings.Contains(ct, CloudEventsContentType) {
 		return NewFromHeaders(req)
 	}
 


### PR DESCRIPTION
Because [the CloudEvents `content-type` header](https://github.com/cloudevents/spec/blob/v0.1/http-transport-binding.md#321-http-content-type) is not necessarily equal to `application/cloudevents+json` and can be, for example, `application/cloudevents+json; charset=UTF-8`, this PR checks if the content type header contains the CloudEventsContentType.

closes #8 
